### PR TITLE
roomservice: Fix search of devices forked to CM

### DIFF
--- a/tools/roomservice.py
+++ b/tools/roomservice.py
@@ -70,7 +70,7 @@ def add_auth(githubreq):
         githubreq.add_header("Authorization","Basic %s" % githubauth)
 
 if not depsonly:
-    githubreq = urllib.request.Request("https://api.github.com/search/repositories?q=%s+user:CyanogenMod+in:name" % device)
+    githubreq = urllib.request.Request("https://api.github.com/search/repositories?q=%s+user:CyanogenMod+in:name+fork:true" % device)
     add_auth(githubreq)
     result = json.loads(urllib.request.urlopen(githubreq).read().decode())
     try:


### PR DESCRIPTION
Commit "roomservice: Improve new device retrieval" introduced a
regression where repositories that were forked to CM were omitted from
search results. This fixes that issue.

Change-Id: I7bf54129b5da1749abe5b2b9a492cb93e6ee41a6